### PR TITLE
Fix getBit error.

### DIFF
--- a/cpp/Makefile.in
+++ b/cpp/Makefile.in
@@ -1,6 +1,6 @@
 CC=g++
 CFLAGS=-fomit-frame-pointer -maes -std=c++11 -msse4.2 -fno-strict-aliasing -pedantic -Wall -Wextra -Wunreachable-code -Wmissing-declarations -Wunused-function -Wno-overlength-strings -Wno-deprecated-declarations -O3
-LDFLAGS= -L/usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lssl -lgmpxx -lgmp
+LDFLAGS= -L/usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lssl -lgmpxx -lgmp -lpthread
 SOURCES= fss-client.cpp fss-server.cpp fss-common.cpp fss-test.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=fss-test

--- a/cpp/fss-common.h
+++ b/cpp/fss-common.h
@@ -66,12 +66,7 @@ struct MPKey {
 
 // Assumes integers are 64 bits
 inline int getBit(uint64_t n, uint64_t pos) {
-    int val = n & (1 << (64 - pos + 1));
-    if (val > 0) {
-        return 1;
-    } else {
-        return 0;
-    }
+    return (n & ( 1 << (64-pos))) >> (64-pos);
 }
 
 // Converts byte array into 64-bit integer

--- a/cpp/fss-server.cpp
+++ b/cpp/fss-server.cpp
@@ -28,7 +28,11 @@ mpz_class evaluateEq(Fss* f, ServerKeyEq *k, uint64_t x) {
     unsigned char temp[2];
     unsigned char out[48];
     for (uint32_t i = 1; i < n+1; i++) {
-        xi = getBit(x, (64-n+i+1));
+        if(i!=n) {
+            xi = getBit(x, (64-n+i+1));
+        } else {
+            xi = 0;
+        }
         prf(out, s, 48, f->aes_keys, f->numKeys);
         memcpy(sArray, out, 32);
         temp[0] = out[32] % 2;
@@ -78,7 +82,11 @@ uint64_t evaluateLt(Fss* f, ServerKeyLt *k, uint64_t x) {
     unsigned char out[64];
     uint64_t temp_v;
     for (uint32_t i = 1; i < n; i++) {
-        xi = getBit(x, (64-n+i+1));
+        if(i!=n) {
+            xi = getBit(x, (64-n+i+1));
+        } else {
+            xi = 0;
+        }
         prf(out, s, 64, f->aes_keys, f->numKeys);
         memcpy(sArray, out, 32);
         temp[0] = out[32] % 2;

--- a/cpp/fss-test.cpp
+++ b/cpp/fss-test.cpp
@@ -26,8 +26,8 @@ int main()
     fin = ans0 - ans1;
     cout << "FSS Eq Match (should be non-zero): " << fin << endl;
     
-    ans0 = evaluateEq(&fServer, &k0, (a+1));
-    ans1 = evaluateEq(&fServer, &k1, (a+1));
+    ans0 = evaluateEq(&fServer, &k0, (a-1));
+    ans1 = evaluateEq(&fServer, &k1, (a-1));
     fin = ans0 - ans1;
     cout << "FSS Eq No Match (should be 0): " << fin << endl;
 


### PR DESCRIPTION
I made the following changes:
- There seems to be a linking error with missing `libpthread` on Ubuntu 18.04 so I link `libpthread` in `Makefile.in`.
- `getBit` is reverted to the previous version with a slightly more elegant implementation.
- Instead of calling getBit(x, 65) and assigning it to `xi`, which is an off-by-one error, 0 is deliberately assigned to `xi`. (This, however, appears to be exhibiting the same behaviour as if you call `getBit(x, 65)` because apparently `1lu<<-1 == 0`. But I think it's a good idea to keep this explicit.)
- `fss-test.cpp` is modified to make sure that it is correct with `a=2`.
