### PR TITLE
Optimize with an added AES-NI enable flag.

### DIFF
--- a/cpp/Makefile.in
+++ b/cpp/Makefile.in
@@ -1,10 +1,13 @@
 CC=g++
 CFLAGS=-fomit-frame-pointer -maes -std=c++11 -msse4.2 -fno-strict-aliasing -pedantic -Wall -Wextra -Wunreachable-code -Wmissing-declarations -Wunused-function -Wno-overlength-strings -Wno-deprecated-declarations -O3
-LDFLAGS= -L/usr/lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lssl -lgmpxx -lgmp -lpthread
+LDFLAGS= -L/usr/lib/x86_64-linux-gnu -Wl,-Bstatic -lcrypto -Wl,-Bdynamic -ldl -lssl -lgmpxx -lgmp -lpthread
 SOURCES= fss-client.cpp fss-server.cpp fss-common.cpp fss-test.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=fss-test
 LIB=libfss.a
+ifeq ($(AESNI), 1)
+    CFLAGS+=-DAESNI
+endif
 
 all: $(SOURCES) $(EXECUTABLE) $(LIB)
 

--- a/cpp/fss-client.cpp
+++ b/cpp/fss-client.cpp
@@ -2,11 +2,13 @@
 #include "fss-client.h"
 
 void initializeClient(Fss* f, uint32_t numBits, uint32_t numParties) {
+#ifndef AESNI
     // check if there is aes-ni instruction
     uint32_t eax, ebx, ecx, edx;
 
     eax = ebx = ecx = edx = 0;
     __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+#endif
 
     f->numBits = numBits;
 
@@ -17,11 +19,15 @@ void initializeClient(Fss* f, uint32_t numBits, uint32_t numParties) {
         if (!RAND_bytes(rand_bytes, 16)) {
             printf("Random bytes failed.\n");
         }
+#ifndef AESNI
         if ((ecx & bit_AES) > 0) {
             aesni_set_encrypt_key(rand_bytes, 128, &(f->aes_keys[i]));
         } else {
             AES_set_encrypt_key(rand_bytes, 128, &(f->aes_keys[i]));
         }
+#else
+        aesni_set_encrypt_key(rand_bytes, 128, &(f->aes_keys[i]));
+#endif
     }
 
     f->numParties = numParties;

--- a/cpp/fss-test.cpp
+++ b/cpp/fss-test.cpp
@@ -78,6 +78,9 @@ int main()
     for(size_t i=0; i<rounds; i++) {
         volatile auto x = evaluateLt(&fServer, &lt_k0, i);
     }
+    for(size_t i=0; i<rounds; i++) {
+        volatile auto x = evaluateEqMParty(&fServer, &mp_keys[1], a);
+    }
     auto t_end = std::chrono::high_resolution_clock::now();
     std::cout << "Benchmark result: " <<
      std::chrono::duration<double, std::milli>(t_end - t_begin).count()

--- a/cpp/fss-test.cpp
+++ b/cpp/fss-test.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include "fss-common.h"
 #include "fss-server.h"
 #include "fss-client.h"
@@ -69,5 +70,17 @@ int main()
     xor_mp = mp_ans0 ^ mp_ans1 ^ mp_ans2;
     cout << "FSS Eq Multi-Party No Match (should be 0): " << xor_mp << endl;
 
+    size_t rounds = 100000;
+    auto t_begin = std::chrono::high_resolution_clock::now();
+    for(size_t i=0; i<rounds; i++) {
+        volatile auto x = evaluateEq(&fServer, &k0, i);
+    }
+    for(size_t i=0; i<rounds; i++) {
+        volatile auto x = evaluateLt(&fServer, &lt_k0, i);
+    }
+    auto t_end = std::chrono::high_resolution_clock::now();
+    std::cout << "Benchmark result: " <<
+     std::chrono::duration<double, std::milli>(t_end - t_begin).count()
+     << " ms" << endl;
     return 1;
 }


### PR DESCRIPTION
If you know your CPU supports AES-NI (which is the case for most modern CPUs), there is no point checking it every time `prf` is called. This is a waste of CPU cycles. I add a flag so that if you compile with `make AESNI=1`, all the checking is disabled by default. With this simple change, evaluation is twice as fast on my i7-6700. You can confirm this by comparing the added benchmark section in `fss-test` between compiling with `make AESNI=1` and the normal `make`.