### PR TITLE
fix compile errors

### DIFF
--- a/go/libfss/common.go
+++ b/go/libfss/common.go
@@ -61,7 +61,7 @@ func randomCryptoInt() uint {
 // True if bit is 1 and False if bit is 0
 // N is the number of bits in uint
 func getBit(n, pos, N uint) byte {
-	return (n & (1 << (N - pos))) >> (N - pos)
+	return byte((n & (1 << (N - pos))) >> (N - pos))
 }
 
 // fixed key PRF (Matyas–Meyer–Oseas one way compression function)

--- a/go/libfss/server.go
+++ b/go/libfss/server.go
@@ -55,10 +55,9 @@ func (f Fss) EvaluatePF(serverNum byte, k FssKeyEq2P, x uint) int {
 	copy(sCurr, k.SInit)
 	tCurr := k.TInit
 	for i := uint(0); i < f.NumBits; i++ {
+        var xBit byte = 0
 		if i != f.N {
-			xBit := getBit(x, (f.N - f.NumBits + i + 1), f.N)
-		} else {
-			xBit := 0
+			xBit = byte(getBit(x, (f.N - f.NumBits + i + 1), f.N))
 		}
 
 		prf(sCurr, f.FixedBlocks, 3, f.Temp, f.Out)


### PR DESCRIPTION
Looks like the Go version of libfss doesn't compile out of the box. I got the following compilation errors:

```
# libfss
libfss/common.go:64:32: cannot use n & (1 << (N - pos)) >> (N - pos) (type uint) as type byte in return argument
libfss/server.go:60:9: cannot use getBit(x, f.N - f.NumBits + i + 1, f.N) (type byte) as type int in assignment
```
I made quick changes so it compiles, and the included tests still run successfully. Didn't do any additional testing to check if it broke something else.